### PR TITLE
Fix weapon selection for some species and backgrounds

### DIFF
--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -2156,7 +2156,7 @@ static weapon_type _starting_weapon_upgrade(weapon_type wp, job_type job,
         return tiny ? wp : WPN_WAR_AXE;
     case WPN_SPEAR:
         // Small fighters can't use tridents with a shield.
-        return fighter && small ? wp : WPN_TRIDENT;
+        return tiny || (fighter && small) ? wp : WPN_TRIDENT;
     case WPN_FALCHION:
         return tiny ? wp : WPN_LONG_SWORD;
     case WPN_QUARTERSTAFF:
@@ -2193,7 +2193,7 @@ static vector<weapon_choice> _get_weapons(const newgame_def& ng)
         {
             weapon_choice wp;
             wp.first = startwep[i];
-            if (job_gets_good_weapons(ng.job) && wp.first == WPN_QUARTERSTAFF)
+            if (job_gets_good_weapons(ng.job) || wp.first == WPN_QUARTERSTAFF)
             {
                 wp.first = _starting_weapon_upgrade(wp.first, ng.job,
                                                     ng.species);

--- a/crawl-ref/source/rltiles/dc-gui.txt
+++ b/crawl-ref/source/rltiles/dc-gui.txt
@@ -212,7 +212,7 @@ backgrounds/NK.png JOB_RECOMMENDED_NIGHT_KNIGHT
 backgrounds/SC.png JOB_RECOMMENDED_STORM_CLERIC
 backgrounds/SP.png JOB_RECOMMENDED_SLIME_PRIEST
 backgrounds/TK.png JOB_RECOMMENDED_TORPOR_KNIGHT
-backgrounds/WA.png JOB_RECOMMENDED_WARRIOR
+backgrounds/Wa.png JOB_RECOMMENDED_WARRIOR
 backgrounds/Wi.png JOB_RECOMMENDED_WITNESS
 backgrounds/Zi.png JOB_RECOMMENDED_ZINJA
 backgrounds/Fn.png JOB_RECOMMENDED_FENCER
@@ -270,7 +270,7 @@ backgrounds/NK.png JOB_NIGHT_KNIGHT
 backgrounds/SC.png JOB_STORM_CLERIC
 backgrounds/SP.png JOB_SLIME_PRIEST
 backgrounds/TK.png JOB_TORPOR_KNIGHT
-backgrounds/WA.png JOB_WARRIOR
+backgrounds/Wa.png JOB_WARRIOR
 backgrounds/Wi.png JOB_WITNESS
 backgrounds/Zi.png JOB_ZINJA
 backgrounds/Fn.png JOB_FENCER


### PR DESCRIPTION
This commit fixes weapon upgrades for backgrounds starting with good quality weapons (e.g. fighters) and gives spears instead of tridents to tiny species (e.g. XL1 proteans) who cannot use tridents.