### PR TITLE
Allow Bunyips to wear Hats

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -854,7 +854,7 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
 {
     const object_class_type base_type = item.base_type;
     if (base_type != OBJ_ARMOUR || you.species == SP_FELID
-        || you.species == SP_BUTTERFLY || you.species == SP_BUNYIP)
+        || you.species == SP_BUTTERFLY)
     {
         if (verbose)
             mpr("You can't wear that.");
@@ -872,7 +872,7 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
         return false;
     }
 
-      if (you.species == SP_UNIPODE && slot != EQ_HELMET)
+      if ((you.species == SP_UNIPODE || you.species == SP_BUNYIP) && slot != EQ_HELMET)
     {
         if (verbose)
             mpr("You can't wear that!");

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -872,7 +872,7 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
         return false;
     }
 
-      if ((you.species == SP_UNIPODE || you.species == SP_BUNYIP) && slot != EQ_HELMET)
+      if (you.species == SP_UNIPODE || you.species == SP_BUNYIP && slot != EQ_HELMET)
     {
         if (verbose)
             mpr("You can't wear that!");


### PR DESCRIPTION
This may help with two problems: 
* bunyips have great difficulty until they find a ring of protection.  By allowing them to wear hats, they can at least enchant a hat if once they find !ea, and some roles begin with a hat.
* Their "neat gimmick" is the fact that they can only benefit from god passives and not god actives.  Ashenzari has potent passives, so it would be helpful for Bunyips to be able to be "bound in armour" for the dodging skill, just like octopodes can.

future bunyip plan: making their body look more alien like the pictures on wikipedia, so that the race doesn't appear to just be a black person.